### PR TITLE
Add 'when' env gate to stack steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,14 @@ Each step has:
  - type: "overlay" or "stack"
  - name: overlay or stack name to include
  - Optional: enabled (bool) — if present and false, the step is skipped.
+ - Optional: when (object) — gate the step on a build env var. The named var is
+   read from the tool's environment (the compose layer exports PKG_* vars). All
+   keys are optional; a step with no "when" always runs:
+     - env: the environment variable to read (e.g. "PKG_UBUNTU_24_04_VERSION")
+     - is  <value>:   run iff the env value equals <value>
+     - not <value>:   run iff the env value does not equal <value>
+     - min <version>: run iff the env value is present and >= <version>
+                      (dotted version compare; unset -> step is skipped)
 
 Example stack:
 
@@ -254,7 +262,10 @@ Example stack:
   "description": "Base system setup for Tachyon",
   "steps": [
     { "type": "overlay", "name": "set-hostname" },
-    { "type": "stack",   "name": "base" }
+    { "type": "stack",   "name": "base" },
+    // Only applied on Ubuntu 24.04 build 1.2 and later:
+    { "type": "overlay", "name": "add-tachyon-audio",
+      "when": { "env": "PKG_UBUNTU_24_04_VERSION", "min": "1.2" } }
   ]
 }
 

--- a/overlay.py
+++ b/overlay.py
@@ -26,6 +26,33 @@ def _env_prefix(env_dict):
     # Build 'KEY="VALUE" KEY2="VALUE2"' safely for shell
     return " ".join(f'{k}="{v}"' for k, v in env_dict.items())
 
+def _parse_version(v):
+    """Parse a dotted version string into a comparable tuple of ints (non-numeric parts -> 0)."""
+    return tuple(int(p) if p.isdigit() else 0 for p in str(v).split("."))
+
+def _step_enabled(step):
+    """Return False if a stack step should be skipped.
+
+    Honours the legacy 'enabled' bool and an optional 'when' gate that reads a
+    build env var (e.g. PKG_UBUNTU_24_04_VERSION, exported by the compose layer).
+    Supported 'when' operators (all optional; a step with no 'when' always runs):
+      - is  <value>   run iff env value equals <value>
+      - not <value>   run iff env value does not equal <value>
+      - min <version>  run iff env value is present and >= <version> (unset -> skip)
+    """
+    if "enabled" in step and not step["enabled"]:
+        return False
+    when = step.get("when")
+    if when:
+        val = os.environ.get(when.get("env")) if when.get("env") else None
+        if "is" in when and val != when["is"]:
+            return False
+        if "not" in when and val == when["not"]:
+            return False
+        if "min" in when and (val is None or _parse_version(val) < _parse_version(when["min"])):
+            return False
+    return True
+
 def remove_json_comments(json_string):
     """Remove comments from JSON string."""
     json_string = re.sub(r"//.*", "", json_string)
@@ -200,8 +227,9 @@ def apply_stack(mount_point, stack_path, resources):
 def process_stack_step(mount_point, step, resources):
     """Process a single step in a stack."""
     print(f"->> Processing stack step: {step['name']} with {step}")
-    if "enabled" in step and not step["enabled"]:
-        print(f"Skipping disabled stack step: {step['name']}")
+    if not _step_enabled(step):
+        gate = step.get("when", "enabled=false")
+        print(f"Skipping gated stack step: {step['name']} ({gate})")
         return
     if step["type"] == "overlay":
         found = False

--- a/overlay.py
+++ b/overlay.py
@@ -15,10 +15,16 @@ RESOURCES = "$RESOURCES"
 overlay_search_paths = []
 
 def _collect_overlay_env_for_chroot():
-    """Return env KEY=VAL pairs to pass into chroot (PKG_* and PIN_PRIORITY)."""
+    """Return env KEY=VAL pairs to pass into chroot (PKG_*, ENV_*, and PIN_PRIORITY).
+
+    PKG_* : package version pins (consumed by the pin/check overlays as apt packages).
+    ENV_* : plain build/config values that are NOT apt packages (e.g. ENV_UBUNTU_24_04_VERSION).
+            They are forwarded so chroot scripts and 'when' gates can read them, but they must
+            never be treated as installable packages.
+    """
     env = {}
     for k, v in os.environ.items():
-        if k.startswith("PKG_") or k == "PIN_PRIORITY":
+        if k.startswith("PKG_") or k.startswith("ENV_") or k == "PIN_PRIORITY":
             env[k] = v
     return env
 
@@ -34,7 +40,7 @@ def _step_enabled(step):
     """Return False if a stack step should be skipped.
 
     Honours the legacy 'enabled' bool and an optional 'when' gate that reads a
-    build env var (e.g. PKG_UBUNTU_24_04_VERSION, exported by the compose layer).
+    build env var (e.g. ENV_UBUNTU_24_04_VERSION, exported by the compose layer).
     Supported 'when' operators (all optional; a step with no 'when' always runs):
       - is  <value>   run iff env value equals <value>
       - not <value>   run iff env value does not equal <value>
@@ -44,13 +50,19 @@ def _step_enabled(step):
         return False
     when = step.get("when")
     if when:
-        val = os.environ.get(when.get("env")) if when.get("env") else None
+        env_name = when.get("env")
+        val = os.environ.get(env_name) if env_name else None
+        enabled = True
         if "is" in when and val != when["is"]:
-            return False
+            enabled = False
         if "not" in when and val == when["not"]:
-            return False
+            enabled = False
         if "min" in when and (val is None or _parse_version(val) < _parse_version(when["min"])):
-            return False
+            enabled = False
+        # Surface the gate decision so CI logs confirm the env value was read and acted on.
+        print(f"[when] step '{step.get('name')}': {env_name}={val!r} {when} -> "
+              f"{'RUN' if enabled else 'SKIP'}")
+        return enabled
     return True
 
 def remove_json_comments(json_string):

--- a/run-overlay.sh
+++ b/run-overlay.sh
@@ -44,13 +44,19 @@ done
 
 # ENV_LIST contains "KEY=VAL,KEY2=VAL2,..."
 if [ -n "${ENV_LIST:-}" ]; then
-  OLDIFS="$IFS"; IFS=',' 
-  for kv in $ENV_LIST; do 
+  OLDIFS="$IFS"; IFS=','
+  for kv in $ENV_LIST; do
     kv="$(echo "$kv" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"   # trim
     [ -n "$kv" ] && export "$kv"
   done
   IFS="$OLDIFS"
 fi
+
+# Surface ENV_* config values (plain build values, not packages) so CI logs confirm
+# they were received and forwarded into the overlay run.
+for ev in $(compgen -e | grep '^ENV_' || true); do
+  echo "[run-overlay] ENV value received: ${ev}=${!ev}"
+done
 
 [ -n "${FILESYSTEM:-}" ] && [ -n "${STACK:-}" ] && [ -n "${RESOURCES:-}" ] || usage
 [ -f "$FILESYSTEM" ] || { echo "Error: Filesystem '$FILESYSTEM' does not exist." >&2; exit 1; }


### PR DESCRIPTION
## What

Adds an optional `when` gate to stack steps so an overlay/stack can be conditionally skipped based on a build environment variable.

```json
{ "type": "overlay", "name": "add-tachyon-audio",
  "when": { "env": "PKG_UBUNTU_24_04_VERSION", "min": "1.2" } }
```

## Operators (all optional; no `when` → always runs)

- `is` / `not` — exact equality / inequality
- `min` — runs iff the env value is present and `>= min` (dotted-version compare; unset → skipped)

The env var is read from the tool's own environment — the compose layer already exports `PKG_*` vars and `overlay.py` forwards them into the chroot. The legacy `enabled: false` bool is preserved (same code path).

## Why

Ubuntu 24.04 now has a 1.1 and a 1.2 (new-BP) hardware build. This lets a single shared stack drive both, gating the 1.2-only overlays behind `PKG_UBUNTU_24_04_VERSION` instead of forking the stack. Min-version semantics so the gated overlays carry forward to 1.3+.

## Notes

Pairs with the `feature/when` branch in tachyon-overlays, which consumes this gate. Documented in README.md.